### PR TITLE
Switch to requiring 6to5-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "6to5ify",
   "description": "6to5 browserify plugin",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://github.com/sebmck/6to5-browserify",
   "repository": {
@@ -12,7 +12,7 @@
     "url": "https://github.com/sebmck/6to5-browserify/issues"
   },
   "dependencies": {
-    "6to5": "^2.0.0",
+    "6to5-core": "^2.8.2",
     "through": "2.3.4",
     "lodash": "^2.4.1"
   }


### PR DESCRIPTION
I bumped the requested version to 2.8.2 because that [appears to be](https://github.com/6to5/6to5/commit/24f70ee4d0faad71af938b592faec69d3811ecd6) when you introduced `6to5-core`.