### PR TITLE
Expose 6to5/polyfill through 6to5ify/polyfill.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,14 @@ browserify().transform(to5ify.configure({
 ```sh
 $ browserify -d -e script.js -t [ 6to5ify --ignore regex --only my_es6_folder ]
 ```
+
+#### ES6 Polyfill
+
+As a convenience, the 6to5 polyfill is exposed in 6to5ify. If you've got
+a browserify-only package this may alleviate the necessity to have
+*both* 6to5 & 6to5ify installed.
+
+```javascript
+// In browser code
+require('6to5ify/polyfill')
+```

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,1 @@
+module.exports = require("6to5-core/polyfill")


### PR DESCRIPTION
For convenience. In recent projects I've been installing both `6to5ify` and `6to5` by default, but I often find myself *only* using `6to5` for `6to5/polyfill`. Since `6to5ify` includes a copy of `6to5-core`, `6to5ify` can expose `6to5-core`'s polyfill as its own to avoid having a redundant installation of `6to5` laying around doing little.